### PR TITLE
add ability to only output deprecated macros

### DIFF
--- a/scripts/macro-usage-report.ts
+++ b/scripts/macro-usage-report.ts
@@ -115,7 +115,7 @@ async function getDeprecatedMacros() {
 
 function formatCell(files: string[], limit = 2): string {
   if (files.length === 0) {
-    return "0";
+    return "-";
   }
 
   return `<span title="${files[0]} …">${files.length}</span>`;

--- a/scripts/macro-usage-report.ts
+++ b/scripts/macro-usage-report.ts
@@ -115,15 +115,18 @@ async function getDeprecatedMacros() {
 
 function formatCell(files: string[], limit = 2): string {
   if (files.length === 0) {
-    return "";
+    return "0";
   }
 
   return `<span title="${files[0]} …">${files.length}</span>`;
 }
 
-async function writeMarkdownTable(filesByMacro: {
-  [macro: string]: Iterable<string>;
-}) {
+async function writeMarkdownTable(
+  filesByMacro: {
+    [macro: string]: Iterable<string>;
+  },
+  deprecatedOnly: string
+) {
   const columns = ["yari", ...ACTIVE_LOCALES];
   process.stdout.write(
     `| macro |${columns.map((column) => ` ${column} `).join("|")}|\n`
@@ -148,15 +151,21 @@ async function writeMarkdownTable(filesByMacro: {
       ...paths.map((path) => formatCell(filterFilesByBase(files, path))),
     ];
 
-    process.stdout.write(`|${cells.map((cell) => ` ${cell} `).join("|")}|\n`);
+    if (deprecatedOnly && deprecatedMacros.includes(macro)) {
+      process.stdout.write(`|${cells.map((cell) => ` ${cell} `).join("|")}|\n`);
+    } else if (!deprecatedOnly) {
+      process.stdout.write(`|${cells.map((cell) => ` ${cell} `).join("|")}|\n`);
+    }
   }
 }
 
 async function main() {
   const macros = await getMacros();
   const filesByMacro = await getFilesByMacro(macros);
+  // get the optional `deprecated-only` flag
+  const deprecatedOnly = process.argv.slice(2, 3)[0];
 
-  await writeMarkdownTable(filesByMacro);
+  await writeMarkdownTable(filesByMacro, deprecatedOnly);
 }
 
 main();


### PR DESCRIPTION
Hey @caugner, I added the ability to pass a `deprecated-only` flag on the command line. This will cause the output to, well, only output deprecated macros :) I also return `0` as opposed to an empty string when there are no usages of a macro. Let me know your thoughts. Thanks!